### PR TITLE
Incorrect Answer child of root node

### DIFF
--- a/Button_Menu.gd
+++ b/Button_Menu.gd
@@ -4,8 +4,8 @@ export(String) var scene_to_load
 export(int) var array_pos
 
 var mouse_sound_effect = load("res://Music/Mouse Click - Sound Effect (HD).wav")
-var popup = preload("res://Popup_menu.tscn")
 var pop_loc = Vector2(350,200)
+var popup = preload("res://Popup_menu.tscn")
 
 func _on_Correct_Answer():
 	print(array_pos)
@@ -24,7 +24,7 @@ func _on_Incorrect_Answer():
 	Global.incorrectCounter += 1
 	#Global.increaseScore(Global.scoreMultiplier[incorrectCounter-1])
 	var pop = popup.instance()
-	add_child(pop)
+	get_tree().get_root().get_node(".").add_child(pop)
 	pop.set_global_position(pop_loc)
 	print("Incorrect Answer")
 

--- a/Code/Information3.tscn
+++ b/Code/Information3.tscn
@@ -70,6 +70,12 @@ margin_bottom = 613.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_fonts/font = SubResource( 2 )
+text = "The other form of coding is referred to as High-level language or
+Programming Language, it is much easier to read compared to low-level language,
+as it consists of human vocabulary. It still communicates with the machine, however,
+it needs to use a compiler in order to turn the High-level language into Machine 
+language.
+"
 clip_text = true
 
 [node name="questionAnswer" type="VBoxContainer" parent="VBoxContainer/Main"]

--- a/Code/Information4.tscn
+++ b/Code/Information4.tscn
@@ -70,6 +70,11 @@ margin_bottom = 613.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_fonts/font = SubResource( 2 )
+text = "There are sub-styles of the High-level language known as paradigms.
+These paradigms usually make the code easier to understand and implement 
+or give the code more functionality. A common type of Paradigm is Object Oriented
+Programming, this is used often within game development to create characters.
+"
 clip_text = true
 
 [node name="questionAnswer" type="VBoxContainer" parent="VBoxContainer/Main"]

--- a/Code/Information5.tscn
+++ b/Code/Information5.tscn
@@ -70,6 +70,13 @@ margin_bottom = 613.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_fonts/font = SubResource( 2 )
+text = "There is a special type of Programming language known as Scripting language, 
+a recognizable Scripting Language is Python. The main difference between
+Programming languages and Scripting languages is that Scripting languages do 
+not need to use a compiler in order to translate code into machine language. 
+Instead it uses an interpreter to instantly translate the code into machine language.
+
+"
 clip_text = true
 
 [node name="questionAnswer" type="VBoxContainer" parent="VBoxContainer/Main"]


### PR DESCRIPTION
I made it so now the popup for the incorrect answer is added as a child of the root node instead of the button, to prevent clipping.